### PR TITLE
_layouts/org.html: Use page.title for name

### DIFF
--- a/_layouts/org.html
+++ b/_layouts/org.html
@@ -5,7 +5,7 @@
   </tr>
   <tr>
     <th>Name</th>
-    <td>{{ page.name }}</td>
+    <td>{{ page.title }}</td>
   </tr>
   <tr>
     <th>slug</th>


### PR DESCRIPTION
Fixes https://github.com/summerofcode/gsoc-orgs/issues/1